### PR TITLE
Removed redundant query from MySQLConnector

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -23,10 +23,6 @@ class MySqlConnector extends Connector implements ConnectorInterface
         // connection's behavior, and some might be specified by the developers.
         $connection = $this->createConnection($dsn, $config, $options);
 
-        if (! empty($config['database'])) {
-            $connection->exec("use `{$config['database']}`;");
-        }
-
         $this->configureIsolationLevel($connection, $config);
 
         $this->configureEncoding($connection, $config);


### PR DESCRIPTION
Hello!

Due to an issue I was having with connecting Laravel to MariaDB's Maxscale, I came across these lines of redundant code. Ironically, they were the actual lines triggering the issue I was having.

Lines 26-28 in Illuminate\Database\Connectors\MySQLConnector perform a query to use the given database name, based on the MySQL Database connection config having a `database` flag.

However, due to how PDO establishes connections, the database is already being chosen within the DSN generation that's being performed, on line 113 and called within the `connect` method on line 17.

This makes the use call being made redundant and can be removed.

I've tested this change on MySQL 5.7, MySQL 8.0 & MariaDB 10.1 & 10.5 and everything works as expected.
